### PR TITLE
 Fix reference bug in message catalog

### DIFF
--- a/packages/node_modules/@node-red/runtime/lib/nodes/context/index.js
+++ b/packages/node_modules/@node-red/runtime/lib/nodes/context/index.js
@@ -104,7 +104,7 @@ function load() {
                             try {
                                 plugin = require("./"+plugins[pluginName].module);
                             } catch(err) {
-                                return reject(new Error(log._("context.error-loading-module", {module:plugins[pluginName].module,message:err.toString()})));
+                                return reject(new Error(log._("context.error-loading-module2", {module:plugins[pluginName].module,message:err.toString()})));
                             }
                         } else {
                             // Assume `module` is an already-required module we can use
@@ -123,7 +123,7 @@ function load() {
                             }
                             log.info(log._("context.log-store-init", {name:pluginName, info:"module="+moduleInfo}));
                         } catch(err) {
-                            return reject(new Error(log._("context.error-loading-module",{module:pluginName,message:err.toString()})));
+                            return reject(new Error(log._("context.error-loading-module2",{module:pluginName,message:err.toString()})));
                         }
                     } else {
                         // Plugin does not specify a 'module'

--- a/packages/node_modules/@node-red/runtime/locales/en-US/runtime.json
+++ b/packages/node_modules/@node-red/runtime/locales/en-US/runtime.json
@@ -30,11 +30,10 @@
             "installed": "Installed module: __name__",
             "install-failed": "Install failed",
             "install-failed-long": "Installation of module __name__ failed:",
-            "install-failed-not-found": "$t(install-failed-long) module not found",
+            "install-failed-not-found": "$t(server.install.install-failed-long) module not found",
             "upgrading": "Upgrading module: __name__ to version: __version__",
             "upgraded": "Upgraded module: __name__. Restart Node-RED to use the new version",
             "upgrade-failed-not-found": "$t(server.install.install-failed-long) version not found",
-            "install-failed-not-found": "$t(server.install.install-failed-long) module not found",
             "uninstalling": "Uninstalling module: __name__",
             "uninstall-failed": "Uninstall failed",
             "uninstall-failed-long": "Uninstall of module __name__ failed:",
@@ -160,12 +159,12 @@
 
     "context": {
         "log-store-init": "Context store  : '__name__' [__info__]",
-        "error-loading-module": "Error loading context store '__module__': __message__ ",
+        "error-loading-module": "Error loading context store: __message__",
+        "error-loading-module2": "Error loading context store '__module__': __message__",
         "error-module-not-defined": "Context store '__storage__' missing 'module' option",
         "error-invalid-module-name": "Invalid context store name: '__name__'",
         "error-invalid-default-module": "Default context store unknown: '__storage__'",
         "unknown-store": "Unknown context store '__name__' specified. Using default store.",
-        "error-loading-module": "Error loading context store: __message__",
         "localfilesystem": {
             "error-circular": "Context __scope__ contains a circular reference that cannot be persisted",
             "error-write": "Error writing context: __message__"

--- a/packages/node_modules/@node-red/runtime/locales/ja/runtime.json
+++ b/packages/node_modules/@node-red/runtime/locales/ja/runtime.json
@@ -8,7 +8,6 @@
             "httpStatic": "HTTP Static    : __path__"
         }
     },
-
     "server": {
         "loading": "パレットノードのロード",
         "palette-editor": {
@@ -30,11 +29,10 @@
             "installed": "モジュール __name__ をインストールしました",
             "install-failed": "インストールに失敗しました",
             "install-failed-long": "モジュール __name__ のインストールに失敗しました:",
-            "install-failed-not-found": "$t(install-failed-long) モジュールが見つかりません",
+            "install-failed-not-found": "$t(server.install.install-failed-long) モジュールが見つかりません",
             "upgrading": "モジュール __name__ をバージョン __version__ に更新します",
             "upgraded": "モジュール __name__ を更新しました。新しいバージョンを使うには、Node-REDを再起動してください。",
             "upgrade-failed-not-found": "$t(server.install.install-failed-long) バージョンが見つかりません",
-            "install-failed-not-found": "$t(server.install.install-failed-long) モジュールが見つかりません",
             "uninstalling": "モジュールをアンインストールします: __name__",
             "uninstall-failed": "アンインストールに失敗しました",
             "uninstall-failed-long": "モジュール __name__ のアンインストールに失敗しました:",
@@ -49,7 +47,6 @@
         "headless-mode": "ヘッドレスモードで実行中です",
         "httpadminauth-deprecated": "httpAdminAuthは非推奨です。代わりに adminAuth を使用してください"
     },
-
     "api": {
         "flows": {
             "error-save": "フローの保存エラー: __message__",
@@ -67,27 +64,25 @@
             "error-enable": "ノードの有効化に失敗しました:"
         }
     },
-
     "comms": {
         "error": "通信チャネルエラー: __message__",
         "error-server": "サーバエラー: __message__",
         "error-send": "送信エラー: __message__"
     },
-
     "settings": {
         "user-not-available": "ユーザ設定を保存できません: __message__",
         "not-available": "設定が利用できません",
         "property-read-only": "プロパティ '__prop__' は読み出し専用です"
     },
-
     "nodes": {
         "credentials": {
-            "error":"クレデンシャルの読み込みエラー: __message__",
-            "error-saving":"クレデンシャルの保存エラー: __message__",
+            "error": "クレデンシャルの読み込みエラー: __message__",
+            "error-saving": "クレデンシャルの保存エラー: __message__",
             "not-registered": "クレデンシャル '__type__' は登録されていません",
             "system-key-warning": "\n\n---------------------------------------------------------------------\nフローのクレデンシャルファイルはシステム生成キーで暗号化されています。\n\nシステム生成キーを何らかの理由で失った場合、クレデンシャルファイルを\n復元することはできません。その場合、ファイルを削除してクレデンシャルを\n再入力しなければなりません。\n\n設定ファイル内で 'credentialSecret' オプションを使って独自キーを設定\nします。変更を次にデプロイする際、Node-REDは選択したキーを用いてクレ\nデンシャルを再暗号化します。 \n\n---------------------------------------------------------------------\n"
         },
         "flows": {
+            "safe-mode": "セーフモードでフローを停止しました。開始するためにはデプロイしてください",
             "registered-missing": "欠落しているノードを登録します: __type__",
             "error": "フローの読み込みエラー: __message__",
             "starting-modified-nodes": "更新されたノードを開始します",
@@ -128,7 +123,6 @@
             }
         }
     },
-    
     "storage": {
         "index": {
             "forbidden-flow-name": "不正なフロー名"
@@ -156,14 +150,17 @@
             }
         }
     },
-
     "context": {
-        "log-store-init": "コンテクストストア : '__name__' [__info__]",
-        "error-loading-module": "コンテクストストア '__module__' のロードでエラーが発生しました: __message__ ",
-        "error-module-not-defined": "コンテクストストア '__storage__' に 'module' オプションが指定されていません",
-        "error-invalid-module-name": "不正なコンテクストストア名: '__name__'",
-        "error-invalid-default-module": "デフォルトコンテクストストアが不明: '__storage__'",
-        "unknown-store": "不明なコンテクストストア '__name__' が指定されました。デフォルトストアを使用します。"        
-      }
-
+        "log-store-init": "コンテキストストア : '__name__' [__info__]",
+        "error-loading-module": "コンテキストストアのロードでエラーが発生しました: __message__",
+        "error-loading-module2": "コンテキストストア '__module__' のロードでエラーが発生しました: __message__",
+        "error-module-not-defined": "コンテキストストア '__storage__' に 'module' オプションが指定されていません",
+        "error-invalid-module-name": "不正なコンテキストストア名: '__name__'",
+        "error-invalid-default-module": "デフォルトコンテキストストアが不明: '__storage__'",
+        "unknown-store": "不明なコンテキストストア '__name__' が指定されました。デフォルトストアを使用します。",
+        "localfilesystem": {
+            "error-circular": "コンテキスト __scope__ は永続化できない循環参照を含んでいます",
+            "error-write": "コンテキスト書込みエラー: __message__"
+        }
+    }
 }


### PR DESCRIPTION
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Proposed changes
I found that there are duplicated key names ("install-failed-not-found" and "error-loading-module") in message catalog, runtime.json. Therefore, I deleted unnecessary "install-failed-not-found" and define new "error-loading-module" as "install-failed-not-found2". At the same time, I updated Japanese message catalog and fix typo.

## Checklist
- [x] I have read the [contribution guidelines](https://github.com/node-red/node-red/blob/master/CONTRIBUTING.md)
- [ ] For non-bugfix PRs, I have discussed this change on the mailing list/slack team.
- [x] I have run `grunt` to verify the unit tests pass
- [ ] I have added suitable unit tests to cover the new/changed functionality